### PR TITLE
Fixes to make IntroLab/sudoku work with python3

### DIFF
--- a/spynnaker_visualisers/glut_framework.py
+++ b/spynnaker_visualisers/glut_framework.py
@@ -99,7 +99,7 @@ class GlutFramework(object):
         "frame_rate_timer",
         "frame_time",
         "frame_time_elapsed",
-        "__logged_errors",
+        "_logged_errors",
         "window"]
 
     def __init__(self):
@@ -109,7 +109,7 @@ class GlutFramework(object):
         self.frame_rate_timer = _PerformanceTimer()
         self.display_timer = _PerformanceTimer()
         self.elapsed_time_in_seconds = 0.0
-        self.__logged_errors = set()
+        self._logged_errors = set()
 
     def start_framework(self, args, title, width, height, posx, posy, fps):
         """ start_framework will initialize framework and start the GLUT run\
@@ -343,6 +343,6 @@ class GlutFramework(object):
 
     def __log_error(self):
         tb = traceback.format_exc()
-        if tb not in self.__logged_errors:
-            self.__logged_errors.add(tb)
+        if tb not in self._logged_errors:
+            self._logged_errors.add(tb)
             traceback.print_exc()

--- a/spynnaker_visualisers/sudoku/sudoku_visualiser.py
+++ b/spynnaker_visualisers/sudoku/sudoku_visualiser.py
@@ -174,7 +174,7 @@ class SudokuPlot(GlutFramework):
         self._draw_cells(cell_width, cell_height)
 
         if self.timestep_ms != 0:
-            x_spacing = cell_width // ((end - start) / self.timestep_ms)
+            x_spacing = cell_width / ((end - start) / self.timestep_ms)
             start_tick = int(start / self.timestep_ms)
             with self.point_mutex:
                 values, probs = self._find_cell_values(start_tick)
@@ -200,7 +200,8 @@ class SudokuPlot(GlutFramework):
 
     @overrides(GlutFramework.keyboard_down)
     def keyboard_down(self, key, x, y):  # @UnusedVariable
-        if key == 32 or key == ' ':
+        key_str = key.decode()
+        if key_str == 32 or key_str == ' ':
             with self.start_condition:
                 if not self.user_pressed_start:
                     print("Starting the simulation")


### PR DESCRIPTION
- some divides were incorrect
- a keyboard press is interpreted as a bytestring, so needs to be decoded
- it doesn't like double-underscore values in __slots__ ... ?