### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "Operating System :: MacOS",
 
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Drop python 3.6 as described in https://github.com/SpiNNakerManchester/SupportScripts/pull/43